### PR TITLE
fix: defensive guards for template JS globals

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 <script src="https://cdn.jsdelivr.net/gh/harvesthq/chosen@gh-pages/chosen.jquery.min.js"></script>
 <link href="https://cdn.jsdelivr.net/gh/harvesthq/chosen@gh-pages/chosen.min.css" rel="stylesheet"/>
   <script src="https://www.jsviews.com/download/jsviews.min.js"></script>
-  <script src="https:////www.jsviews.com/download/sample-tag-controls/jsonview/jsonview.js"></script>
+  <script src="https://www.jsviews.com/download/sample-tag-controls/jsonview/jsonview.js"></script>
   <script src="amazon-cognito-auth.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/lodash@4.17.15/lodash.min.js"></script>
   <script src="jquery-deparam.min.js"></script>

--- a/templates/7thsea.js
+++ b/templates/7thsea.js
@@ -1,3 +1,8 @@
+(function() {
+    ['dbinfo','databasesort','headerize','searchables','labels','templates','updates'].forEach(function(g) {
+        if (typeof window[g] === 'undefined') window[g] = {};
+    });
+})();
 dbinfo['7thsea'] = {
     'name': "7th Sea CCG",
     'nameshort':'7thsea',

--- a/templates/dune.js
+++ b/templates/dune.js
@@ -1,3 +1,8 @@
+(function() {
+    ['dbinfo','databasesort','headerize','searchables','labels','templates','updates'].forEach(function(g) {
+        if (typeof window[g] === 'undefined') window[g] = {};
+    });
+})();
 dbinfo['dune'] = {
     'name': "Dune CCG",
     'nameshort':'dune',

--- a/templates/initiald.js
+++ b/templates/initiald.js
@@ -1,3 +1,8 @@
+(function() {
+    ['dbinfo','databasesort','headerize','searchables','labels','templates','updates'].forEach(function(g) {
+        if (typeof window[g] === 'undefined') window[g] = {};
+    });
+})();
 dbinfo['initiald'] = {
     'name': "Initial D CCG",
     'nameshort':'initiald',

--- a/templates/l5r.js
+++ b/templates/l5r.js
@@ -1,3 +1,8 @@
+(function() {
+    ['dbinfo','databasesort','headerize','searchables','labels','templates','updates'].forEach(function(g) {
+        if (typeof window[g] === 'undefined') window[g] = {};
+    });
+})();
 /* TODO */
 // advanced/basic switch  (tri-level)?
 // hide search switch

--- a/templates/lbs.js
+++ b/templates/lbs.js
@@ -1,3 +1,8 @@
+(function() {
+    ['dbinfo','databasesort','headerize','searchables','labels','templates','updates'].forEach(function(g) {
+        if (typeof window[g] === 'undefined') window[g] = {};
+    });
+})();
 // advanced/basic switch  (tri-level)?
 // hide search switch
 console.log('Loading lbs');

--- a/templates/pathfinder-pawns.js
+++ b/templates/pathfinder-pawns.js
@@ -1,3 +1,8 @@
+(function() {
+    ['dbinfo','databasesort','headerize','searchables','labels','templates','updates','blurb'].forEach(function(g) {
+        if (typeof window[g] === 'undefined') window[g] = {};
+    });
+})();
 dbinfo['pathfinder-pawns'] = {
     'name': "Pathfinder Pawns",
     'nameshort':'pathfinder-pawns',

--- a/templates/warlord.js
+++ b/templates/warlord.js
@@ -1,3 +1,8 @@
+(function() {
+    ['dbinfo','databasesort','headerize','searchables','labels','templates','updates'].forEach(function(g) {
+        if (typeof window[g] === 'undefined') window[g] = {};
+    });
+})();
 dbinfo['warlord'] = {
     'name': "Warlord: Saga of the Storm CCG",
     'nameshort':'warlord',


### PR DESCRIPTION
## Problem

Template files (warlord.js, dune.js, pathfinder-pawns.js, etc.) directly access shared globals (dbinfo, databasesort, headerize, searchables, labels, templates, updates, blurb) declared in oracle.js. If oracle.js fails to load or encounters an error before those declarations, the templates crash with:

```
Uncaught TypeError: Cannot set properties of undefined (setting 'warlord')
```

## Fix

- Wrap each template file in an IIFE that initializes all shared globals on `window` if they don't already exist
- Also fixes a malformed URL in index.html (`https:////www.jsviews.com` → `https://www.jsviews.com`)

## Files changed

- `index.html` — fix malformed jsviews URL
- `templates/*.js` (7 files) — add defensive global initialization guards